### PR TITLE
[fix] Enable page scrolling on mobile devices

### DIFF
--- a/stvl_simple_chat_enhancer.user.js
+++ b/stvl_simple_chat_enhancer.user.js
@@ -620,7 +620,7 @@
         GM_addStyle("#userlistcontainer.boostList table > tbody > tr > td {padding:2px;}");
         
         // stvl css fix
-        GM_addStyle("body{margin-top:0px !important; overflow:hidden;} #header{margin-top:-20px;}");
+        GM_addStyle("@media (min-width: 992px) { body{margin-top:0px !important; overflow:hidden;} #header{margin-top:-20px;} }");
     }
 
     // add pip container


### PR DESCRIPTION
Add the overflow:hidden property only on devices wider than 991px - otherwise scrolling doesn't work on mobile devices.